### PR TITLE
Check for missing dataset earlier

### DIFF
--- a/ckanext/os/controllers/preview_list.py
+++ b/ckanext/os/controllers/preview_list.py
@@ -38,10 +38,12 @@ class PreviewList(BaseController):
         if not id:
             abort(409, 'Dataset not identified')
         preview_list = pylons_session.get('preview_list', [])
+
         pkg = model.Package.get(id)
+        if not pkg:
+            abort(404, 'Dataset not found')
+
         if not self._get(pkg.id):
-            if not pkg:
-                abort(404, 'Dataset not found')
             extent = (pkg.extras.get('bbox-north-lat'),
                       pkg.extras.get('bbox-west-long'),
                       pkg.extras.get('bbox-east-long'),


### PR DESCRIPTION
When package is not found `pkg` is `None` and `pkg.id` causes an exception.
